### PR TITLE
simplified/fixed vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.py[cod]
 .*
 staticfiles
+dcpython/dcpython.sqlite3
 
 # C extensions
 *.so

--- a/README.rst
+++ b/README.rst
@@ -30,26 +30,15 @@ Clone your copy of github repository to your working directory (replace <your-us
     $ git clone git@github.com:<your-username>/dcpython-django.git
     $ cd dcpython-django
 
-Install Vagrant caching plugin::
-
-    $ vagrant plugin install vagrant-cachier
-
 Start the vagrant environment::
 
     $ vagrant up
 
-YOU WILL GET HUGE RED ERRORS: check to ensure this is a permissions issue with postgres, then continue with these instructions
-TODO - please help me fix this bug!
-
-Log into the vagrant vm::
-
-    $ vagrant ssh
-    $ cd /vagrant
-    $ sh config_db.sh
-
 Start the django server::
 
-    $ foreman start
+    $ heroku local
+
+Heroku will install a bunch of stuff the first time you run this command, then it will start a dev server.
 
 You can now visit the Django site at http://localhost:5000
 
@@ -77,7 +66,7 @@ From the vagrant ssh command line
 Start django::
 
     $ cd /vagrant
-    $ foreman start
+    $ heroku local
 
 Django manage.py::
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,11 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "precise32"
-  config.vm.box_url = "http://files.vagrantup.com/precise32.box"
-
-  config.cache.enable :apt
-  config.cache.auto_detect = true
+  config.vm.box = "ubuntu/trusty64"
 
   config.vm.provision :shell, :path => "bootstrap.sh"
 
@@ -24,37 +20,4 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # config.vm.network :forwarded_port, guest: 80, host: 8080
   config.vm.network:forwarded_port, guest: 5000, host:5000
 
-  # Create a private network, which allows host-only access to the machine
-  # using a specific IP.
-  # config.vm.network :private_network, ip: "192.168.33.10"
-
-  # Create a public network, which generally matched to bridged network.
-  # Bridged networks make the machine appear as another physical device on
-  # your network.
-  # config.vm.network :public_network
-
-  # If true, then any SSH connections made will enable agent forwarding.
-  # Default value: false
-  # config.ssh.forward_agent = true
-
-  # Share an additional folder to the guest VM. The first argument is
-  # the path on the host to the actual folder. The second argument is
-  # the path on the guest to mount the folder. And the optional third
-  # argument is a set of non-required options.
-  # config.vm.synced_folder "../data", "/vagrant_data"
-
-  # Provider-specific configuration so you can fine-tune various
-  # backing providers for Vagrant. These expose provider-specific options.
-  # Example for VirtualBox:
-  #
-  # config.vm.provider :virtualbox do |vb|
-  #   # Don't boot with headless mode
-  #   vb.gui = true
-  #
-  #   # Use VBoxManage to customize the VM. For example to change memory:
-  #   vb.customize ["modifyvm", :id, "--memory", "1024"]
-  # end
-  #
-  # View the documentation for the provider you're using for more
-  # information on available options.
 end

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,11 +1,6 @@
 #!/bin/sh
 export PYTHONPATH=$PYTHONPATH:/vagrant
 
-# set utf locale for postgres
-export LANGUAGE="en_US.UTF-8"
-export LANG="en_US.UTF-8"
-export LC_ALL="en_US.UTF-8"
-
 # update everything
 sudo apt-get update
 sudo apt-get upgrade
@@ -32,13 +27,8 @@ sudo python3.4 -m ensurepip
 echo "*** installing requirements for python3.4, using pip3"
 sudo pip3 install -r /vagrant/requirements.txt
 
-# have to properly set locale for postgres setup
-
-# sudo -u postgres pg_createcluster --start -e UTF-8 9.1 main
-# sudo -u postgres pg_createcluster --start -e UTF-8 --locale=en_US.UTF8 9.1 main
-
-# setup postgresql
-sudo -u postgres createuser --superuser vagrant
-sudo -u postgres psql -c "alter user postgres with password '1234';"
-sudo -u postgres psql -c 'CREATE DATABASE dcpython;'
-/vagrant/config_db.sh
+# setup database
+/vagrant/manage.py syncdb
+/vagrant/manage.py migrate
+/vagrant/manage.py loaddata /vagrant/dcpython/app/fixtures/debug_data.json
+/vagrant/manage.py loaddata /vagrant/dcpython/events/fixtures/debug_data.json

--- a/config_db.sh
+++ b/config_db.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-/vagrant/manage.py syncdb
-/vagrant/manage.py migrate
-/vagrant/manage.py loaddata /vagrant/dcpython/app/fixtures/debug_data.json
-/vagrant/manage.py loaddata /vagrant/dcpython/events/fixtures/debug_data.json

--- a/dcpython/settings.py
+++ b/dcpython/settings.py
@@ -48,27 +48,13 @@ MANAGERS = ADMINS
 import dj_database_url
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2', # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': 'dcpython',                      # Or path to database file if using sqlite3.
-        # The following settings are not used with sqlite3:
-        'USER': 'vagrant',
-        'PASSWORD': '1234',
-        'HOST': '',                      # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
-        'PORT': '',                      # Set to empty string for default.
+        'ENGINE': 'django.db.backends.sqlite3', # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
+        'NAME': os.path.join(ROOT_DIR, 'dcpython.sqlite3'),  # Or path to database file if using sqlite3.
     }
 }
 
 if "DATABASE_URL" in os.environ:
     DATABASES['default'] = dj_database_url.config()
-
-try:
-    import sys
-    print("Creating sqlite test database")
-    if 'test' in sys.argv:
-        DATABASES['default'] = {'ENGINE': 'django.db.backends.sqlite3'}
-except ImportError:
-    print("Tried to set up test database, but sys module could not be imported")
-
 
 # Honor the 'X-Forwarded-Proto' header for request.is_secure()
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')


### PR DESCRIPTION
upgraded to 14.04 lts using a default vagrant box.

removed cache plugin

switched over to sqlite for development. We will likely
want to switch to sqlite entirely if we switch off of heroku.

provisioning now happens seemlessly - no errors that have to
be worked around.