### PR TITLE
Add job post explanation text from blog post

### DIFF
--- a/dcpython/app/templates/app/resources.html
+++ b/dcpython/app/templates/app/resources.html
@@ -17,15 +17,53 @@
           <p>We provide a <a href="http://chat-logs.dcpython.org">log of our online conversations</a>. In addition to our chats, we provide logs as a service to other members of the open source community. If you are interested in having your channel logged, please <a href="mailto:aclark@dcpython.org">get in touch</a>.</p>
         <h2>Code</h2>    
           <p>We have some <a href="https://github.com/DCPython">code at GitHub</a>.</p>  
-        <h2>Jobs</h2>    
-          <p>DC Python helps Python programmers get jobs and local companies find Python programmers. We allow job postings in our <a href='http://www.meetup.com/DCPython/messages/boards/'>meetup.com/DCPython message board</a> provided the following criteria are met:</p>
-            <ul>
-                <li>You are posting for a Python job; please don't try to recruit PHP or Ruby or .NET developers.</li>
-                <li>You send a link to our mailing list with [JOB] in the subject line of the email.</li>
-                <li>You are an active member of the DC Python community and/or you are willing to <a href="http://dcpython.org/donate">make a donation</a>.</li>
-                <li>You make your own original post, rather than replying to or reusing someone else's.</li>
-            </ul>
+        <h2 id="jobs">Jobs</h2>    
+          <p>DC Python helps Python programmers get jobs and local companies find Python programmers.
+<p>The <a class="reference external" href="//www.meetup.com/DCPython/messages/boards/">DC Python Job Board</a> includes:</p>
+<ul class="simple">
+<li><a class="reference external" href="//www.meetup.com/DCPython/messages/boards/forum/13783032">A board for Python programmers seeking work</a>.</li>
+<li><a class="reference external" href="//www.meetup.com/DCPython/messages/boards/forum/617991">A board for employers seeking Python programmers</a>.</li>
+<li><a class="reference external" href="//www.meetup.com/DCPython/messages/boards/forum/13783122">A board for organizations &amp; venues willing (or even excited) to host our meetups</a>.</li>
+</ul>
+
+<p>We allow job postings in our <a href='//www.meetup.com/DCPython/messages/boards/'>meetup.com/DCPython message board</a> provided the following criteria are met:</p>
+	    <h3 id="job-posting-instructions">Job Posting Instructions</h3>
+	      <p><strong>Please follow these rules to post to the DC Python Job Board</strong>.</p>
+	      <ol class="arabic simple">
+	      <li>Join the <a class="reference external" href="//www.meetup.com/DCPython/join/">DC Python Meetup</a>.</li>
+	      <li><a class="reference external" href="//www.meetup.com/DCPython/messages/boards/forum/617991">Create a job posting</a> on message board.</li>
+	      <li>Send a link to your post to the DC Python mailing list: <a class="reference external" href="mailto:DCPython-list@meetup.com">DCPython-list&#64;meetup.com</a>.</li>
+	      </ol>
+	      <blockquote>
+	      <ul class="simple">
+	      <li><strong>Include [JOB] in the subject line, some brief introductory text, a link to your post &amp; nothing else. E.g.</strong></li>
+	      </ul>
+	      </blockquote>
+	      <pre class="literal-block">
+Wed Oct  7 16:45:52 EDT 2015
+From: aclark&#64;aclark.net
+To: DCPython-list&#64;meetup.com
+Subject: [JOB] ACLARK.NET, LLC seeking Python Web Developer
+
+Hi DC Python,
+
+My name is Alex Clark and I am the President of ACLARK.NET, LLC: the most awesome Python shop in Washington, DC, USA. I am interested in hiring a Python web developer to fill an awesome position working directly for me:
+
+- http://www.meetup.com/DCPython/messages/boards/thread/41146492
+
+I hope to hear from you soon!
+
+Alex
+	      </pre>
+	      <p><strong>In your email to the list, please do <em>not</em> include:</strong></p>
+	      <ul class="simple">
+	      <li><strong>The full text of the job listing</strong></li>
+	      <li><strong>Links to external job postings</strong></li>
+	      </ul>
+	      <p>Also please send email to the list with the <strong>same email address</strong> you used to join Meetup, else <strong>Meetup won't accept it</strong>.</p>
+	      <p>Good luck!</p>
     </div>
+
     <div class="col-lg-6">  
         <h1>DC Python Friends</h1>
           <h3>DC PyLadies</h3>
@@ -58,6 +96,3 @@
   </div>
 </div>
 {% endblock %}
-
-
-      


### PR DESCRIPTION
Add job instruction blog post to Resources.
Edit out blog post personal language.
Edit out redundant existing job text.
Light edits for clarity and link text best practices.
Add anchor for both "Jobs" and "Job Posting Instructions" (#jobs and #job-posting-instructions, respectively).