### PR TITLE
Revert "Fix #96 error "reverse accessor clashing""

### DIFF
--- a/dcpython/app/models.py
+++ b/dcpython/app/models.py
@@ -1,16 +1,13 @@
-from django.db import models
-from django.contrib.auth.models import AbstractUser
-
-class User(AbstractUser):
-    meetup_username = models.CharField(max_length=100, blank=True, null=True)
-    meetup_id = models.IntegerField(blank=True, null=True)
-
-class ServiceSync(models.Model):
-    """
-    keep track of the last time a sync event took place
-    """
-    service = models.CharField(max_length=200)
-    last_synced = models.CharField(max_length=50)
-
-class Meta:
-    db_table = 'auth_user'
+#from django.db import models
+#from django.contrib.auth.models import AbstractUser
+#
+#class User(AbstractUser):
+#    meetup_username = models.CharField(max_length=100, blank=True, null=True)
+#    meetup_id = models.IntegerField(blank=True, null=True)
+#
+#class ServiceSync(models.Model):
+#    """
+#    keep track of the last time a sync event took place
+#    """
+#    service = models.CharField(max_length=200)
+#    last_synced = models.CharField(max_length=50)


### PR DESCRIPTION
Reverts DCPython/dcpython-django#102. Actually, ``Meta`` needs to be a nested class e.g.

```
class User(AbstractUser):
    meetup_username = models.CharField(max_length=100, blank=True, null=True)
    meetup_id = models.IntegerField(blank=True, null=True)

    class Meta:
        db_table = 'auth_user'
```

But in testing now, that doesn't seem to help.